### PR TITLE
Updated config.yaml fields

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,6 @@ hooks:
     secret: secretkey
     taskinfo:
       namespace: demo
-      task: my-appsody-build
-      gitResourceName: hello-springboot-git-source
-      imageResourceName: hello-springboot-registry-image
-      
+      taskrefname: my-appsody-build
+      gitsourceresourcename: hello-springboot-git-source
+      dockerimageresourcename: hello-springboot-registry-image


### PR DESCRIPTION
Fixes: #1 

If we look at the code  https://github.com/zhiminwen/gitea-webhook-tekton/blob/master/webhook.go#L15-L21, the contents should be:

```yaml
hooks:
  - repo: mmello/unifi-docker
    secret: secret1235
    taskinfo:
      namespace: default 
      taskrefname: source-to-image
      gitsourceresourcename: unifi-docker-git
      dockerimageresourcename: unifi-internal-registry-image-url
``` 

Then testing the new yaml, we have the following:

```
gitea-webhook-tekton-6654ddb8c8-5qx24
[gitea-webhook-tekton-6654ddb8c8-5qx24] 2019/10/08 19:30:36 main.Config{Hooks:[]main.HookAction{main.HookAction{Secret:"secret1235", Repo:"mmello/unifi-docker", TaskInfo:main.TaskToRun{Namespace:"default", ServiceAccount:"", TaskRefName:"source-to-image", GitSourceResourceName:"unifi-docker-git", DockerImageResourceName:"unifi-internal-registry-image-url"}}}} 
[gitea-webhook-tekton-6654ddb8c8-5qx24] 2019/10/08 19:31:00 repo=mmello/unifi-docker,payload repo=mmello/unifi-docker, secret=secret1235, payload secret=secret1235 
[gitea-webhook-tekton-6654ddb8c8-5qx24] 2019/10/08 19:31:00 exec command for repo:mmello/unifi-docker 
```

Please let me know your thoughts @zhiminwen 

Thanks for putting this together!